### PR TITLE
feat: add header double tap and staff gated input

### DIFF
--- a/app/src/main/java/com/bitchat/android/core/ui/utils/ModifierExt.kt
+++ b/app/src/main/java/com/bitchat/android/core/ui/utils/ModifierExt.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 fun Modifier.singleOrTripleClickable(
     onSingleClick: () -> Unit,
     onTripleClick: () -> Unit,
+    onDoubleClick: (() -> Unit)? = null,
     clickTimeThreshold: Long = 300L
 ): Modifier = composed {
     var tapCount by remember { mutableIntStateOf(0) }
@@ -20,12 +21,11 @@ fun Modifier.singleOrTripleClickable(
     this.clickable {
         val currentTime = System.currentTimeMillis()
 
-        if (currentTime - lastTapTime < clickTimeThreshold) {
-            tapCount++
+        tapCount = if (currentTime - lastTapTime < clickTimeThreshold) {
+            tapCount + 1
         } else {
-            tapCount = 1
+            1
         }
-
         lastTapTime = currentTime
 
         // Cancel any pending single click action
@@ -41,6 +41,10 @@ fun Modifier.singleOrTripleClickable(
                         onSingleClick()
                     }
                 }
+            }
+            2 -> {
+                onDoubleClick?.invoke()
+                tapCount = 0
             }
             3 -> {
                 // Triple click detected - execute immediately

--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -252,6 +252,7 @@ fun ChatHeaderContent(
                 onNicknameChange = viewModel::setNickname,
                 onTitleClick = onShowAppInfo,
                 onTripleTitleClick = onTripleClick,
+                onBackClick = onBackClick,
                 onSidebarClick = onSidebarClick,
                 viewModel = viewModel
             )
@@ -307,11 +308,16 @@ private fun PrivateChatHeader(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.align(Alignment.Center)
         ) {
-            
+
             Text(
                 text = peerNickname,
                 style = MaterialTheme.typography.titleMedium,
-                color = Color(0xFFFF9500) // Orange
+                color = Color(0xFFFF9500), // Orange
+                modifier = Modifier.singleOrTripleClickable(
+                    onSingleClick = {},
+                    onDoubleClick = { onBackClick() },
+                    onTripleClick = {}
+                )
             )
 
             Spacer(modifier = Modifier.width(4.dp))
@@ -388,7 +394,11 @@ private fun ChannelHeader(
             color = Color(0xFFFF9500), // Orange to match input field
             modifier = Modifier
                 .align(Alignment.Center)
-                .clickable { onSidebarClick() }
+                .singleOrTripleClickable(
+                    onSingleClick = { onSidebarClick() },
+                    onDoubleClick = { onBackClick() },
+                    onTripleClick = {}
+                )
         )
         
         // Leave button - positioned on the right
@@ -411,6 +421,7 @@ private fun MainHeader(
     onNicknameChange: (String) -> Unit,
     onTitleClick: () -> Unit,
     onTripleTitleClick: () -> Unit,
+    onBackClick: () -> Unit,
     onSidebarClick: () -> Unit,
     viewModel: ChatViewModel
 ) {
@@ -441,7 +452,11 @@ private fun MainHeader(
                 color = colorScheme.primary,
                 modifier = Modifier.singleOrTripleClickable(
                     onSingleClick = onTitleClick,
-                    onTripleClick = { showStaffDialog = true }
+                    onDoubleClick = { onBackClick() },
+                    onTripleClick = {
+                        onTripleTitleClick()
+                        showStaffDialog = true
+                    }
                 )
             )
 

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -14,6 +14,9 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.zIndex
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
+import com.bitchat.android.util.StaffAuth
 
 /**
  * Main ChatScreen - REFACTORED to use component-based architecture
@@ -217,6 +220,11 @@ private fun ChatInputSection(
     nickname: String,
     colorScheme: ColorScheme
 ) {
+    val context = LocalContext.current
+    val isInMainChat = selectedPrivatePeer == null && currentChannel == null
+    val canSendInMain = StaffAuth.isStaff(context)
+    val canSend = !isInMainChat || canSendInMain
+
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = colorScheme.background,
@@ -226,19 +234,30 @@ private fun ChatInputSection(
             HorizontalDivider(color = colorScheme.outline.copy(alpha = 0.3f))
             // Command suggestions box
 
-            
+
             // Mention suggestions box
 
 
             MessageInput(
                 value = messageText,
-                onValueChange = onMessageTextChange,
-                onSend = onSend,
+                onValueChange = { if (canSend) onMessageTextChange(it) },
+                onSend = { if (canSend) onSend() },
                 selectedPrivatePeer = selectedPrivatePeer,
                 currentChannel = currentChannel,
                 nickname = nickname,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .alpha(if (canSend) 1f else 0.5f)
             )
+
+            if (isInMainChat && !canSendInMain) {
+                Text(
+                    text = "Écriture réservée au STAFF. Triple-tap sur \"Echo\" pour activer le mode staff.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colorScheme.onSurface.copy(alpha = 0.6f),
+                    modifier = Modifier.padding(horizontal = 12.dp)
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- support optional double-tap in `singleOrTripleClickable`
- double-tap chat titles to navigate back when possible
- disable and grey out main chat input unless staff is authenticated

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e7855074832ea191ae057e2854c7